### PR TITLE
add header and source files when building for ios

### DIFF
--- a/qtzeroconf.pri
+++ b/qtzeroconf.pri
@@ -44,6 +44,12 @@ macx {
 	QMAKE_CXXFLAGS+= -I$$PWD
 }
 
+ios {
+	HEADERS+= $$PWD/qzeroconf.h $$PWD/bonjour_p.h
+	SOURCES+= $$PWD/bonjour.cpp
+	QMAKE_CXXFLAGS+= -I$$PWD
+}
+
 android {
 	QMAKE_CXXFLAGS+= -I$$PWD
 	QMAKE_CFLAGS+= -I$$PWD


### PR DESCRIPTION
Simple fix to include header and source files when building for iOS. I've tested that it builds and works.

Thanks for the great library!