### PR TITLE
undefine the 'interface' macro present when compiling with msvc

### DIFF
--- a/qzeroconf.h
+++ b/qzeroconf.h
@@ -31,6 +31,8 @@
 #include <QHostAddress>
 #include <QMap>
 
+#undef interface
+
 struct QZeroConfService
 {
 	QString			name;


### PR DESCRIPTION
A bit of a problem when compiling on Windows. `interface` is defined as `struct`, which throws everything off inside the QZeroConfService struct.

This will helpfully undefine `interface` and allow compilation. The other solution, of course, is to rename the interface variable.