### PR TITLE
removed Qt keywords to provide broader compatibility

### DIFF
--- a/qzeroconf.h
+++ b/qzeroconf.h
@@ -84,7 +84,7 @@ public:
 	void addServiceTxtRecord(QString name, QString value);
 	void clearServiceTxtRecords();
 
-signals:
+Q_SIGNALS:
 	void servicePublished(void);
 	void error(QZeroConf::error_t);
 	void serviceAdded(QZeroConfService *);
@@ -95,7 +95,7 @@ private:
 	QZeroConfPrivate	*pri;
 	QMap<QString, QZeroConfService *> services;
 
-private slots:
+
 
 };
 


### PR DESCRIPTION
small changes, which enable users to use QtZeroconf in projects which require the ```CONFIG += no_keywords``` flag. 
