### PR TITLE
Fixed internal datahandling for the avahiclient implementation

### DIFF
--- a/avahiclient.cpp
+++ b/avahiclient.cpp
@@ -126,7 +126,7 @@ public:
 				return;
 
 			zcs = ref->pub->services[key];
-			ref->pub->services.remove(key);
+            ref->pub->services.remove(key);
 			emit ref->pub->serviceRemoved(zcs);
 			break;
 		case AVAHI_BROWSER_ALL_FOR_NOW:
@@ -176,7 +176,7 @@ public:
 						zcs.appendTxt(pair.at(0));
 					txt = txt->next;
 				}
-				ref->pub->services.insert(key, zcs);
+
 			}
 
 			char a[AVAHI_ADDRESS_STR_MAX];
@@ -191,6 +191,8 @@ public:
 				emit ref->pub->serviceAdded(zcs);
 			else
 				emit ref->pub->serviceUpdated(zcs);
+
+            ref->pub->services.insert(key, zcs);
 		}
 		else if (ref->pub->services.contains(key)) {	// delete service if exists and unable to resolve
 			zcs = ref->pub->services[key];

--- a/avahiclient.cpp
+++ b/avahiclient.cpp
@@ -234,6 +234,7 @@ public:
 QZeroConf::QZeroConf(QObject *parent) : QObject (parent)
 {
 	pri = new QZeroConfPrivate(this);
+    qRegisterMetaType<QZeroConfService>("QZeroConfService");
 }
 
 QZeroConf::~QZeroConf()

--- a/avahicore.cpp
+++ b/avahicore.cpp
@@ -274,6 +274,7 @@ public:
 QZeroConf::QZeroConf(QObject *parent) : QObject (parent)
 {
 	pri = new QZeroConfPrivate(this);
+    qRegisterMetaType<QZeroConfService>("QZeroConfService");
 }
 
 QZeroConf::~QZeroConf()

--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -37,6 +37,8 @@ QZeroConfPrivate::QZeroConfPrivate(QZeroConf *parent)
 	browserSocket = NULL;
 	resolverSocket = NULL;
 	addressSocket = NULL;
+
+    qRegisterMetaType<QZeroConfService>();
 }
 
 void QZeroConfPrivate::bsRead()

--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -37,6 +37,8 @@ QZeroConfPrivate::QZeroConfPrivate(QZeroConf *parent)
 	browserSocket = NULL;
 	resolverSocket = NULL;
 	addressSocket = NULL;
+
+
 }
 
 void QZeroConfPrivate::bsRead()
@@ -261,6 +263,7 @@ void QZeroConfPrivate::cleanUp(DNSServiceRef toClean)
 
 QZeroConf::QZeroConf(QObject *parent) : QObject (parent)
 {
+    qRegisterMetaType<QZeroConfService>("QZeroConfService");
 	pri = new QZeroConfPrivate(this);
 }
 

--- a/example/window.cpp
+++ b/example/window.cpp
@@ -31,6 +31,7 @@
 #include <QNetworkInterface>
 #include <QHeaderView>
 #include "window.h"
+#include <QDebug>
 
 #ifdef Q_OS_IOS
 	#define	OS_NAME		"iOS"
@@ -150,6 +151,8 @@ void mainWindow::addService(QZeroConfService zcs)
 	qint32 row;
 	QTableWidgetItem *cell;
 
+    qDebug() << "Added service: " << zcs;
+
 	row = table.rowCount();
 	table.insertRow(row);
 	cell = new QTableWidgetItem(zcs.name());
@@ -166,6 +169,8 @@ void mainWindow::removeService(QZeroConfService zcs)
 {
 	qint32 i, row;
 	QTableWidgetItem *nameItem, *ipItem;
+
+    qDebug() << "Removed service: " << zcs;
 
 	QList <QTableWidgetItem*> search = table.findItems(zcs.name(), Qt::MatchExactly);
 	for (i=0; i<search.size(); i++) {

--- a/example/window.cpp
+++ b/example/window.cpp
@@ -55,7 +55,8 @@ mainWindow::mainWindow()
 	buildGUI();
 
 	connect(&zeroConf, &QZeroConf::serviceAdded, this, &mainWindow::addService);
-	connect(&zeroConf, &QZeroConf::serviceRemoved, this, &mainWindow::removeService);
+    connect(&zeroConf, &QZeroConf::serviceUpdated, this, &mainWindow::updateService);
+    connect(&zeroConf, &QZeroConf::serviceRemoved, this, &mainWindow::removeService);
 	connect(qGuiApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)), this, SLOT(appStateChanged(Qt::ApplicationState)));
 
 	publishEnabled = 1;
@@ -163,6 +164,11 @@ void mainWindow::addService(QZeroConfService zcs)
 	#if !(defined(Q_OS_IOS) || defined(Q_OS_ANDROID))
 	setFixedSize(table.horizontalHeader()->length() + 60, table.verticalHeader()->length() + 100);
 	#endif
+}
+
+void mainWindow::updateService(QZeroConfService zcs)
+{
+    qDebug() << "Service updated: " << zcs;
 }
 
 void mainWindow::removeService(QZeroConfService zcs)

--- a/example/window.h
+++ b/example/window.h
@@ -51,7 +51,8 @@ private slots:
 	void startPublishClicked();
 	void stopPublishClicked();
 	void addService(QZeroConfService item);
-	void removeService(QZeroConfService item);
+    void removeService(QZeroConfService item);
+    void updateService(QZeroConfService zcs);
 };
 
 #endif /* WINDOW_H_ */

--- a/qzeroconfservice.cpp
+++ b/qzeroconfservice.cpp
@@ -4,15 +4,15 @@
 class QZeroConfServiceData : public QSharedData
 {
 public:
-		QString			name;
-		QString			type;
-		QString			domain;
-		QString			host;
-		QHostAddress	ip;
-		QHostAddress	ipv6;
-		quint32			interfaceIndex;
-		quint16			port = 0;
-		QMap			<QByteArray, QByteArray> txt;
+    QString			name;
+    QString			type;
+    QString			domain;
+    QString			host;
+    QHostAddress	ip;
+    QHostAddress	ipv6;
+    quint32			interfaceIndex;
+    quint16			port = 0;
+    QMap			<QByteArray, QByteArray> txt;
 
 };
 
@@ -28,9 +28,9 @@ QZeroConfService::QZeroConfService(const QZeroConfService &rhs) : data(rhs.data)
 
 QZeroConfService &QZeroConfService::operator=(const QZeroConfService &rhs)
 {
-		if (this != &rhs)
-				data.operator=(rhs.data);
-		return *this;
+    if (this != &rhs)
+        data.operator=(rhs.data);
+    return *this;
 }
 
 QZeroConfService::~QZeroConfService()
@@ -40,106 +40,115 @@ QZeroConfService::~QZeroConfService()
 
 QString QZeroConfService::name() const
 {
-		return data->name;
+    return data->name;
 }
 
 void QZeroConfService::setName(const QString &name)
 {
-		data->name = name;
+    data->name = name;
 }
 
 QString QZeroConfService::type() const
 {
-		return data->type;
+    return data->type;
 }
 
 void QZeroConfService::setType(const QString &type)
 {
-		data->type = type;
+    data->type = type;
 }
 
 QString QZeroConfService::domain() const
 {
-		return  data->domain;
+    return  data->domain;
 }
 
 void QZeroConfService::setDomain(const QString &domain)
 {
-		data->domain = domain;
+    data->domain = domain;
 }
 
 QString QZeroConfService::host() const
 {
-		return data->host;
+    return data->host;
 }
 
 void QZeroConfService::setHost(const QString &host)
 {
-		data->host = host;
+    data->host = host;
 }
 
 QHostAddress QZeroConfService::ip() const
 {
-		return data->ip;
+    return data->ip;
 }
 
 void QZeroConfService::setIp(QHostAddress &ip)
 {
-		data->ip = ip;
+    data->ip = ip;
 }
 
 QHostAddress QZeroConfService::ipv6() const
 {
-		return data->ipv6;
+    return data->ipv6;
 }
 
 void QZeroConfService::setIpv6(const QHostAddress &ipv6)
 {
-		data->ipv6 = ipv6;
+    data->ipv6 = ipv6;
 }
 
 quint32 QZeroConfService::interfaceIndex() const
 {
-		return  data->interfaceIndex;
+    return  data->interfaceIndex;
 }
 
 void QZeroConfService::setInterfaceIndex(const quint32 &interfaceIndex)
 {
-		data->interfaceIndex = interfaceIndex;
+    data->interfaceIndex = interfaceIndex;
 }
 
 quint16 QZeroConfService::port() const
 {
-		return data->port;
+    return data->port;
 }
 
 void QZeroConfService::setPort(const quint16 port)
 {
-		data->port = port;
+    data->port = port;
 }
 
 QMap<QByteArray, QByteArray> QZeroConfService::txt() const
 {
-		return data->txt;
+    return data->txt;
 }
 
 void QZeroConfService::setTxt(const QMap<QByteArray, QByteArray> txt)
 {
-		data->txt = txt;
+    data->txt = txt;
 }
 
 void QZeroConfService::appendTxt(QByteArray idx, QByteArray val)
 {
-		data->txt[idx] = val;
+    data->txt[idx] = val;
 }
 
 bool QZeroConfService::isValid() const
 {
 
-		return (!data->name.isEmpty());
+    return (!data->name.isEmpty());
 }
 
 bool QZeroConfService::operator==(const QZeroConfService &rhs) const
 {
-		return this->name() == rhs.name() && (this->ip() == rhs.ip() || this->ipv6() == rhs.ipv6());
+    return this->name() == rhs.name() && (this->ip() == rhs.ip() || this->ipv6() == rhs.ipv6());
+}
+
+QDebug operator<<(QDebug debug, const QZeroConfService &service)
+{
+
+    QDebugStateSaver saver(debug);
+    debug.nospace() << "Zeroconf Service: " << service.name() << "@" << service.host() << ":" << service.port() ;
+    return debug.maybeSpace();
+
 }

--- a/qzeroconfservice.cpp
+++ b/qzeroconfservice.cpp
@@ -4,15 +4,15 @@
 class QZeroConfServiceData : public QSharedData
 {
 public:
-		QString			name;
-		QString			type;
-		QString			domain;
-		QString			host;
-		QHostAddress	ip;
-		QHostAddress	ipv6;
-		quint32			interfaceIndex;
-		quint16			port = 0;
-		QMap			<QByteArray, QByteArray> txt;
+    QString			name;
+    QString			type;
+    QString			domain;
+    QString			host;
+    QHostAddress	ip;
+    QHostAddress	ipv6;
+    quint32			interfaceIndex;
+    quint16			port = 0;
+    QMap			<QByteArray, QByteArray> txt;
 
 };
 
@@ -28,9 +28,9 @@ QZeroConfService::QZeroConfService(const QZeroConfService &rhs) : data(rhs.data)
 
 QZeroConfService &QZeroConfService::operator=(const QZeroConfService &rhs)
 {
-		if (this != &rhs)
-				data.operator=(rhs.data);
-		return *this;
+    if (this != &rhs)
+        data.operator=(rhs.data);
+    return *this;
 }
 
 QZeroConfService::~QZeroConfService()
@@ -40,106 +40,115 @@ QZeroConfService::~QZeroConfService()
 
 QString QZeroConfService::name() const
 {
-		return data->name;
+    return data->name;
 }
 
 void QZeroConfService::setName(const QString &name)
 {
-		data->name = name;
+    data->name = name;
 }
 
 QString QZeroConfService::type() const
 {
-		return data->type;
+    return data->type;
 }
 
 void QZeroConfService::setType(const QString &type)
 {
-		data->type = type;
+    data->type = type;
 }
 
 QString QZeroConfService::domain() const
 {
-		return  data->domain;
+    return  data->domain;
 }
 
 void QZeroConfService::setDomain(const QString &domain)
 {
-		data->domain = domain;
+    data->domain = domain;
 }
 
 QString QZeroConfService::host() const
 {
-		return data->host;
+    return data->host;
 }
 
 void QZeroConfService::setHost(const QString &host)
 {
-		data->host = host;
+    data->host = host;
 }
 
 QHostAddress QZeroConfService::ip() const
 {
-		return data->ip;
+    return data->ip;
 }
 
 void QZeroConfService::setIp(QHostAddress &ip)
 {
-		data->ip = ip;
+    data->ip = ip;
 }
 
 QHostAddress QZeroConfService::ipv6() const
 {
-		return data->ipv6;
+    return data->ipv6;
 }
 
 void QZeroConfService::setIpv6(const QHostAddress &ipv6)
 {
-		data->ipv6 = ipv6;
+    data->ipv6 = ipv6;
 }
 
 quint32 QZeroConfService::interfaceIndex() const
 {
-		return  data->interfaceIndex;
+    return  data->interfaceIndex;
 }
 
 void QZeroConfService::setInterfaceIndex(const quint32 &interfaceIndex)
 {
-		data->interfaceIndex = interfaceIndex;
+    data->interfaceIndex = interfaceIndex;
 }
 
 quint16 QZeroConfService::port() const
 {
-		return data->port;
+    return data->port;
 }
 
 void QZeroConfService::setPort(const quint16 port)
 {
-		data->port = port;
+    data->port = port;
 }
 
 QMap<QByteArray, QByteArray> QZeroConfService::txt() const
 {
-		return data->txt;
+    return data->txt;
 }
 
 void QZeroConfService::setTxt(const QMap<QByteArray, QByteArray> txt)
 {
-		data->txt = txt;
+    data->txt = txt;
 }
 
 void QZeroConfService::appendTxt(QByteArray idx, QByteArray val)
 {
-		data->txt[idx] = val;
+    data->txt[idx] = val;
 }
 
 bool QZeroConfService::isValid() const
 {
 
-		return (!data->name.isEmpty());
+    return (!data->name.isEmpty());
 }
 
 bool QZeroConfService::operator==(const QZeroConfService &rhs) const
 {
-		return this->name() == rhs.name() && (this->ip() == rhs.ip() || this->ipv6() == rhs.ipv6());
+    return this->name() == rhs.name() && (this->ip() == rhs.ip() || this->ipv6() == rhs.ipv6());
+}
+
+QDebug operator<<(QDebug debug, const QZeroConfService &service)
+{
+
+    QDebugStateSaver saver(debug);
+    debug.nospace() << "Zeroconf Service: " + service.name() + " @ " + service.host() + " ("+ service.ip().toString()  + ":" + QString::number( service.port()) + ")";
+    return debug.maybeSpace();
+
 }

--- a/qzeroconfservice.cpp
+++ b/qzeroconfservice.cpp
@@ -141,7 +141,7 @@ bool QZeroConfService::isValid() const
 
 bool QZeroConfService::operator==(const QZeroConfService &rhs) const
 {
-    return this->name() == rhs.name() && (this->ip() == rhs.ip() || this->ipv6() == rhs.ipv6());
+    return this->name() == rhs.name() &&  (this->ip() == rhs.ip() || this->ipv6() == rhs.ipv6());
 }
 
 QDebug operator<<(QDebug debug, const QZeroConfService &service)

--- a/qzeroconfservice.h
+++ b/qzeroconfservice.h
@@ -3,6 +3,7 @@
 
 #include <QSharedDataPointer>
 #include <QHostAddress>
+#include <QDebug>
 
 class QZeroConfServiceData;
 
@@ -48,6 +49,8 @@ public:
 private:
 		QSharedDataPointer<QZeroConfServiceData> data;
 };
+
+ QDebug operator<<(QDebug debug, const QZeroConfService &service);
 
 Q_DECLARE_METATYPE(QZeroConfService)
 


### PR DESCRIPTION
Hi Jon, 

this patch solves the issue you reported to me by mail. The issue was simply that the internal data, stored in the QMap was never updated with the ip data. For the bonjour implementation there was no such issue. The core implementation (Android?) isn't tested, as I am not having a platform / sdk for this. 

I also merged your latest changes and added a debugging output for the QZeroConfService Class, which is already used by the example.

If there are some formatting issues, simply let me know and I'll do my best to fix them. (I had a really hard time to force QtCreator to use tabs instead of spaces)

Regards
Matthias