### PR TITLE
only create one avahi server instance

### DIFF
--- a/avahicore.cpp
+++ b/avahicore.cpp
@@ -55,7 +55,9 @@ public:
 		avahi_server_config_init(&config);
 		config.publish_workstation = 0;
 
-		server = avahi_server_new(poll, &config, serverCallback, this, &error);
+		if (!server) {
+			server = avahi_server_new(poll, &config, serverCallback, this, &error);
+		}
 		if (!server) {
 			return;
 		}
@@ -256,7 +258,7 @@ public:
 
 	QZeroConf *pub;
 	const AvahiPoll *poll;
-	AvahiServer *server;
+	static AvahiServer *server;
 	AvahiServerConfig config;
 	AvahiSEntryGroup *group;
 	AvahiSServiceBrowser *browser;
@@ -267,6 +269,7 @@ public:
 	qint32 port;
 };
 
+AvahiServer* QZeroConfPrivate::server = nullptr;
 
 QZeroConf::QZeroConf(QObject *parent) : QObject (parent)
 {


### PR DESCRIPTION
On platforms which create their own avahi server (e.g. Android)
the previous code would assert as there can only be one server
instantiated but creating multiple QtZeroConf objects tried
to create multiple servers.