### PR TITLE
add support for compiling for ubuntu touch

### DIFF
--- a/qtzeroconf.pri
+++ b/qtzeroconf.pri
@@ -8,7 +8,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
 }
 
 # below for >= Qt5
-linux:!android {
+linux:!android:!ubuntu {
 	HEADERS+= $$PWD/qzeroconf.h $$PWD/avahi-qt/qt-watch.h  $$PWD/avahi-qt/qt-watch_p.h
 	SOURCES+= $$PWD/avahiclient.cpp $$PWD/avahi-qt/qt-watch.cpp
 	LIBS+= -lavahi-client -lavahi-common
@@ -57,16 +57,21 @@ ios {
 	QMAKE_CXXFLAGS+= -I$$PWD
 }
 
-android {
+ubuntu|android: {
 	QMAKE_CXXFLAGS+= -I$$PWD
 	QMAKE_CFLAGS+= -I$$PWD
 	ACM = $$PWD/avahi-common
 	ACR = $$PWD/avahi-core
 	HEADERS+= $$PWD/qzeroconf.h $$PWD/avahi-qt/qt-watch.h  $$PWD/avahi-qt/qt-watch_p.h
-	SOURCES+= $$PWD/avahicore.cpp $$PWD/avahi-qt/qt-watch.cpp
+        SOURCES+= $$PWD/avahicore.cpp $$PWD/avahi-qt/qt-watch.cpp
 	# avahi-common
-	DEFINES+= HAVE_STRLCPY GETTEXT_PACKAGE
-	SOURCES+= $$ACM/address.c
+        android: {
+            DEFINES+= HAVE_STRLCPY GETTEXT_PACKAGE
+        }
+        ubuntu: {
+            DEFINES+= _GNU_SOURCE GETTEXT_PACKAGE
+        }
+        SOURCES+= $$ACM/address.c
 	SOURCES+= $$ACM/alternative.c
 	SOURCES+= $$ACM/domain.c
 	SOURCES+= $$ACM/error.c


### PR DESCRIPTION
This allows building it for Ubuntu phone with included avahi. Avahi is not running on Ubuntu phones but the android portion works just fine with some little tweaking of the defines.