### PR TITLE
macOS: Fixed undetected service stop/start while the application is running

### DIFF
--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -86,14 +86,7 @@ void QZeroConfPrivate::resolve(QZeroConfService zcs)
 
 	err = DNSServiceResolve(&resolver->DNSresolverRef, kDNSServiceFlagsTimeout, zcs->interfaceIndex(), zcs->name().toUtf8(), zcs->type().toUtf8(), zcs->domain().toUtf8(), static_cast<DNSServiceResolveReply>(resolverCallback), resolver);
 	if (err == kDNSServiceErr_NoError) {
-		int sockfd = DNSServiceRefSockFD(resolver->DNSresolverRef);
-		if (sockfd == -1) {
-			resolver->cleanUp();
-		}
-		else {
-			resolver->resolverNotifier = new QSocketNotifier(sockfd, QSocketNotifier::Read);
-			connect(resolver->resolverNotifier, &QSocketNotifier::activated, resolver, &Resolver::resolverReady);
-		}
+		resolver->resolverReady();
 	}
 	else {
 		resolver->cleanUp();
@@ -185,14 +178,7 @@ void DNSSD_API QZeroConfPrivate::resolverCallback(DNSServiceRef, DNSServiceFlags
 	}
 	err = DNSServiceGetAddrInfo(&resolver->DNSaddressRef, kDNSServiceFlagsForceMulticast, interfaceIndex, resolver->ref->protocol, hostName, static_cast<DNSServiceGetAddrInfoReply>(addressReply), resolver);
 	if (err == kDNSServiceErr_NoError) {
-		int sockfd = DNSServiceRefSockFD(resolver->DNSaddressRef);
-		if (sockfd == -1) {
-			resolver->cleanUp();
-		}
-		else {
-			resolver->addressNotifier = new QSocketNotifier(sockfd, QSocketNotifier::Read);
-			connect(resolver->addressNotifier, &QSocketNotifier::activated, resolver, &Resolver::addressReady);
-		}
+		resolver->addressReady();
 	}
 	else {
 		resolver->cleanUp();


### PR DESCRIPTION
**Environment**: macOS 10.13

**Test case**:

I started the application that uses QtZeroConf. It properly detected all services on startup. I kept the application running.

While testing service stop and start on another embedded device on the same network I discovered that QtZeroConf properly detects when a service is removed, however it does not detect (or very seldom) when the service is started again.

I analysed the issue and resolved it by replacing event from the socket with direct call to resolver in two places.

Stop and start of a service is reliably detected every time.