### PR TITLE
Fixed handling of TXT records longer than 127 bytes

### DIFF
--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -160,7 +160,7 @@ void DNSSD_API QZeroConfPrivate::resolverCallback(DNSServiceRef, DNSServiceFlags
 		return;
 	}
 
-	qint16 recLen;
+	uchar recLen;
 	while (txtLen > 0)		// add txt records
 	{
 		recLen = txtRecord[0];


### PR DESCRIPTION
While browsing services on Windows (through Bonjour SDK) I discovered that I was unable to browser services if some of them published TXT records longer than 127 bytes (the maximum length of TXT records is actually 255 bytes).

The problem was due to the usage of a signed variable (`qint16`) while spooling the length of the TXT record out of the buffer, in `QZeroConfPrivate::resolverCallback()` within bonjour.cpp file. If the length of the record was longer that 127 bytes, then it was interpreted as signed during the conversion to `qint16` and hence generated a negative value for variable `recLen`, thus causing the execution to hang within the function.

Changing the declaration type of `recLen` from qint16 to `uchar` fixed the problem.