### PR TITLE
bonjour-sdk: fix gcc compilation on windows

### DIFF
--- a/bonjour-sdk/CommonServices.h
+++ b/bonjour-sdk/CommonServices.h
@@ -743,7 +743,7 @@ typedef int ssize_t;
 //	 Standard Types
 //===========================================================================================================================
 
-#if ( !defined( INT8_MIN ) )
+#if ( !defined( __GNUC__ ) ) && ( !defined( INT8_MIN ) )
 
     #define INT8_MIN                    SCHAR_MIN
 


### PR DESCRIPTION
QtZeroconf fails with type definition errors with GCC on Windows. So i ignore them if the compiler is GCC.