### PR TITLE
Fix linker error due to missing export of debug operator

### DIFF
--- a/qzeroconfservice.h
+++ b/qzeroconfservice.h
@@ -53,6 +53,6 @@ typedef QSharedPointer<QZeroConfServiceData> QZeroConfService;
 
 Q_DECLARE_METATYPE(QZeroConfService)
 
-QDebug operator<<(QDebug debug, const QZeroConfService &service);
+QDebug Q_ZEROCONF_EXPORT operator<<(QDebug debug, const QZeroConfService &service);
 
 #endif // QZEROCONFSERVICE_H


### PR DESCRIPTION
When building QtZeroConf as a shared library I got a linker error in the example application on Windows because the debug `operator<<` for QZeroConfService was not properly exported. This commit fixes this issue