### PR TITLE
Add proper CMake config file to install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ if(ANDROID)
 endif()
 
 # install
+set(INSTALL_CMAKEDIR "lib/cmake/${PROJECT_NAME}" CACHE STRING "Installation directory for cmake config files")
 set_target_properties(QtZeroConf PROPERTIES PUBLIC_HEADER
     "${PUBLIC_HEADERS}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,15 @@ set_target_properties(QtZeroConf PROPERTIES PUBLIC_HEADER
     "${PUBLIC_HEADERS}"
 )
 install(TARGETS QtZeroConf
+    EXPORT QtZeroConfConfig
     LIBRARY DESTINATION lib
     PUBLIC_HEADER DESTINATION include/QtZeroConf
+)
+export(TARGETS QtZeroConf
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/QtZeroConfConfig.cmake
+)
+install(EXPORT QtZeroConfConfig
+    DESTINATION ${INSTALL_CMAKEDIR}
 )
 
 if(BUILD_EXAMPLE)


### PR DESCRIPTION
This is an addition to my PR #41. While using QtZeroConf with CMake in another project of mine I noticed that the installation and the subsequent usage wasn't working as expected. This commit fixes that so that once installed QtZeroConf can be easily integrated with find_package into other projects.
