### PR TITLE
Add support for compiling for Ubuntu Touch aka UBPorts

### DIFF
--- a/qtzeroconf.pri
+++ b/qtzeroconf.pri
@@ -8,7 +8,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
 }
 
 # below for >= Qt5
-linux:!android {
+linux:!android:!ubports {
 	HEADERS+= $$PWD/qzeroconf.h $$PWD/avahi-qt/qt-watch.h  $$PWD/avahi-qt/qt-watch_p.h
 	SOURCES+= $$PWD/avahiclient.cpp $$PWD/avahi-qt/qt-watch.cpp
 	LIBS+= -lavahi-client -lavahi-common
@@ -57,7 +57,7 @@ ios {
 	QMAKE_CXXFLAGS+= -I$$PWD
 }
 
-android {
+ubports|android: {
 	QMAKE_CXXFLAGS+= -I$$PWD
 	QMAKE_CFLAGS+= -I$$PWD
 	ACM = $$PWD/avahi-common
@@ -65,7 +65,12 @@ android {
 	HEADERS+= $$PWD/qzeroconf.h $$PWD/avahi-qt/qt-watch.h  $$PWD/avahi-qt/qt-watch_p.h
 	SOURCES+= $$PWD/avahicore.cpp $$PWD/avahi-qt/qt-watch.cpp
 	# avahi-common
-	DEFINES+= HAVE_STRLCPY GETTEXT_PACKAGE
+	android: {
+		DEFINES+= HAVE_STRLCPY GETTEXT_PACKAGE
+	}
+	ubports: {
+		DEFINES+= _GNU_SOURCE GETTEXT_PACKAGE
+	}
 	SOURCES+= $$ACM/address.c
 	SOURCES+= $$ACM/alternative.c
 	SOURCES+= $$ACM/domain.c


### PR DESCRIPTION
This is piggy packing on the Android implementation using avahicore as there is no avahi-daemon installed on Ubuntu Phone devices.

I'm using this for years but never upstreamed it given the little popularity of the platform. Still, the Ubuntu Touch community is growing so IMO it could make a valid platform to be supported.

Admittedly, the main reason why I'm submitting this now, is that the upcoming branch to move the Android implementation away from avahicore would make the entire avahicore implementation obsolete. So in the hope that it could still be kept in the long run, I'm trying to give it an actual purpose with this. 