### PR TITLE
Fix parsing of TXT records if value contains '='

### DIFF
--- a/avahicore.cpp
+++ b/avahicore.cpp
@@ -183,11 +183,11 @@ public:
 				while (txt)	// get txt records
 				{
 					QByteArray avahiText((const char *)txt->text, txt->size);
-					QList<QByteArray> pair = avahiText.split('=');
-					if (pair.size() == 2)
-						zcs->m_txt[pair.at(0)] = pair.at(1);
+					const size_t pos = avahiText.indexOf('=');
+					if (pos < 0)
+						zcs->m_txt[avahiText] = "";
 					else
-						zcs->m_txt[pair.at(0)] = "";
+						zcs->m_txt[avahiText.left(pos)] = avahiText.mid(pos + 1, -1);
 					txt = txt->next;
 				}
 				ref->pub->services.insert(key, zcs);

--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -167,11 +167,11 @@ void DNSSD_API QZeroConfPrivate::resolverCallback(DNSServiceRef, DNSServiceFlags
 		recLen = txtRecord[0];
 		txtRecord++;
 		QByteArray avahiText(reinterpret_cast<const char *>(txtRecord), recLen);
-		QList<QByteArray> pair = avahiText.split('=');
-		if (pair.size() == 2)
-			resolver->zcs->m_txt[pair.at(0)] = pair.at(1);
+		const size_t pos = avahiText.indexOf('=');
+		if (pos < 0)
+			resolver->zcs->m_txt[avahiText] = "";
 		else
-			resolver->zcs->m_txt[pair.at(0)] = "";
+			resolver->zcs->m_txt[avahiText.left(pos)] = avahiText.mid(pos + 1, -1);
 
 		txtLen-= recLen + 1;
 		txtRecord+= recLen;


### PR DESCRIPTION
TXT record values can also contain equals signs. The current implementation would consider any record where the value contains an equals sign as an empty record.