### PR TITLE
AvahiCode + Bonjour: use correct datatype for pos

### DIFF
--- a/avahicore.cpp
+++ b/avahicore.cpp
@@ -183,7 +183,7 @@ public:
 				while (txt)	// get txt records
 				{
 					QByteArray avahiText((const char *)txt->text, txt->size);
-					const ssize_t pos = avahiText.indexOf('=');
+					const int pos = avahiText.indexOf('=');
 					if (pos < 0)
 						zcs->m_txt[avahiText] = "";
 					else

--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -167,7 +167,7 @@ void DNSSD_API QZeroConfPrivate::resolverCallback(DNSServiceRef, DNSServiceFlags
 		recLen = txtRecord[0];
 		txtRecord++;
 		QByteArray avahiText(reinterpret_cast<const char *>(txtRecord), recLen);
-		const ssize_t pos = avahiText.indexOf('=');
+		const int pos = avahiText.indexOf('=');
 		if (pos < 0)
 			resolver->zcs->m_txt[avahiText] = "";
 		else


### PR DESCRIPTION
ssize_t is not available on windows (at least not with msvc2019). Use
int as QByteArray::indexOf is defined with int return type.