### PR TITLE
avahicore and avahiclient: fixed TXT records update on existing services

### DIFF
--- a/avahiclient.cpp
+++ b/avahiclient.cpp
@@ -150,17 +150,21 @@ public:
 				zcs->m_host = host_name;
 				zcs->m_interfaceIndex = interface;
 				zcs->m_port = port;
-				while (txt)	// get txt records
-				{
-					QByteArray avahiText((const char *)txt->text, txt->size);
-					const ssize_t pos = avahiText.indexOf('=');
-					if (pos < 0)
-						zcs->m_txt[avahiText] = "";
-					else
-						zcs->m_txt[avahiText.left(pos)] = avahiText.mid(pos + 1, -1);
-					txt = txt->next;
-				}
+				
 				ref->pub->services.insert(key, zcs);
+			}
+
+			// Update TXT records anyway
+			zcs->m_txt.clear();
+			while (txt)
+			{
+				QByteArray avahiText((const char *)txt->text, txt->size);
+				const ssize_t pos = avahiText.indexOf('=');
+				if (pos < 0)
+					zcs->m_txt[avahiText] = "";
+				else
+					zcs->m_txt[avahiText.left(pos)] = avahiText.mid(pos + 1, -1);
+				txt = txt->next;
 			}
 
 			char a[AVAHI_ADDRESS_STR_MAX];

--- a/avahicore.cpp
+++ b/avahicore.cpp
@@ -180,17 +180,21 @@ public:
 				zcs->m_host = host_name;
 				zcs->m_interfaceIndex = interface;
 				zcs->m_port = port;
-				while (txt)	// get txt records
-				{
-					QByteArray avahiText((const char *)txt->text, txt->size);
-					const int pos = avahiText.indexOf('=');
-					if (pos < 0)
-						zcs->m_txt[avahiText] = "";
-					else
-						zcs->m_txt[avahiText.left(pos)] = avahiText.mid(pos + 1, -1);
-					txt = txt->next;
-				}
+				
 				ref->pub->services.insert(key, zcs);
+			}
+
+			// Update TXT records anyway
+			zcs->m_txt.clear();
+			while (txt)
+			{
+				QByteArray avahiText((const char *)txt->text, txt->size);
+				const int pos = avahiText.indexOf('=');
+				if (pos < 0)
+					zcs->m_txt[avahiText] = "";
+				else
+					zcs->m_txt[avahiText.left(pos)] = avahiText.mid(pos + 1, -1);
+				txt = txt->next;
 			}
 
 			char a[AVAHI_ADDRESS_STR_MAX];


### PR DESCRIPTION
Hello. I just noticed that using avahi (avahicore/avahiclient) TXT records of existing services are not getting updated properly...

I mean: if you have an existing service on the network and then update its TXT records somehow QtZeroConf successfully emits the corresponding `serviceUpdated()` signal, but the `QZeroConfService` object passed as parameter still references the previous TXT records (the records before the service update).

It's easy to fix that by simply re-processing TXT records before emitting the signal... the same process is already in place for newly-detected services and so it is enough to move the corresponding code block outside the `if` (considering the clear the `m_txt` collection anyway before doing that).