### PR TITLE
Fix "multiple socket notifiers for same socket"

### DIFF
--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -190,6 +190,8 @@ void DNSSD_API QZeroConfPrivate::resolverCallback(DNSServiceRef, DNSServiceFlags
 			resolver->cleanUp();
 		}
 		else {
+			// Fix "multiple socket notifiers for same socket" warning
+			resolver->addressNotifier.clear();
 			resolver->addressNotifier = QSharedPointer<QSocketNotifier>::create(sockfd, QSocketNotifier::Read);
 			connect(resolver->addressNotifier.data(), &QSocketNotifier::activated, resolver, &Resolver::addressReady);
 		}


### PR DESCRIPTION
Some background info:  
I have multiple python applications that announce themselves using the python zeroconf implementation. I noticed that when the number of applications increases beyond ~20 I'm starting to get the warning "multiple socket notifiers for same socket XXXX and type Read" in my C++ client application. After some debugging, I found that only the `addressNotifier` of the `Resolver` class caused this warning. Looking at 

https://github.com/jbagg/QtZeroConf/blob/74402496b07134808504ef5a45ae83d23f07cda9/bonjour.cpp#L182-L185

it seems to me that there are cases where the `resolverCallback` is called multiple times for the same `Resolver`. My first try was then just to add something similar that checks if the `resolver->addressNotifier` is already existing and has the same socket. If that's the case then the `QSocketNotifier` is also deleted. This works and I'm not getting any warnings anymore.

<br>

It's quite interesting to me, though, that the code does not seem to work without this addition even though the effect is essentially the same: `QSharedPointer` would delete the `QSocketNotifier` if it already existed in this line

https://github.com/jbagg/QtZeroConf/blob/74402496b07134808504ef5a45ae83d23f07cda9/bonjour.cpp#L193

The same is true for `clear()` here

```cpp
			resolver->addressNotifier.clear();
```

The `QSocketNotifier` only gets deleted if this `QSharedPointer` had the last reference to it (which it is in this case).