### PR TITLE
Add optional parameter for binding service to specific interface

### DIFF
--- a/bonjour.cpp
+++ b/bonjour.cpp
@@ -268,7 +268,7 @@ QZeroConf::~QZeroConf()
 	delete pri;
 }
 
-void QZeroConf::startServicePublish(const char *name, const char *type, const char *domain, quint16 port)
+void QZeroConf::startServicePublish(const char *name, const char *type, const char *domain, quint16 port, quint32 interface)
 {
 	DNSServiceErrorType err;
 
@@ -277,7 +277,7 @@ void QZeroConf::startServicePublish(const char *name, const char *type, const ch
 		return;
 	}
 
-	err = DNSServiceRegister(&pri->dnssRef, 0, 0,
+	err = DNSServiceRegister(&pri->dnssRef, 0, interface,
 			name,
 			type,
 			domain,

--- a/qzeroconf.h
+++ b/qzeroconf.h
@@ -50,7 +50,7 @@ public:
 	};
     QZeroConf(QObject *parent = Q_NULLPTR);
 	~QZeroConf();
-	void startServicePublish(const char *name, const char *type, const char *domain, quint16 port);
+	void startServicePublish(const char *name, const char *type, const char *domain, quint16 port, quint32 interface = 0);
 	void stopServicePublish(void);
 	bool publishExists(void);
 	inline void startBrowser(QString type)


### PR DESCRIPTION
This adds an optional parameter to `registerService` that allows specifying a specific interface index to bind to. I added it since I needed to publish a service specifically on the loopback interface. Since the parameter is optional, it shouldn't break any existing code.

This seems to duplicate the work of #25 but that PR was never merged. I think that PR also had an error where it would pass the wrong argument to `avahi_server_add_service_strlst` when using the previous / default behavior of `registerService`. (It ought to pass `AVAHI_IF_UNSPEC` for the interface index, which has a value of `-1` not `0`.)

Full disclosure: I have not tested the Android specific code as I don't have a dev environment for that. The change is quite small though and I'm _pretty sure_ I got it right. But it should be verified.