### PR TITLE
cmake: Bump cmake_minimum_required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(QtZeroConf VERSION 0.1.0)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Network)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2381401
